### PR TITLE
[Feat] Allow dynamic entity id

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -2,13 +2,25 @@ Fliplet().then(function() {
   var data = Fliplet.Widget.getData();
   var appId = Fliplet.Env.get('appId');
 
+  if (!$('[name="sso_login_url"]').val()) {
+    data.dynamicEntityId = data.dynamicEntityId || true;
+  }
+
   $(window).on('resize', Fliplet.Widget.autosize);
 
   var $dataSources = $('[name="dataSource"]');
   var $emailAddress = $('[name="emailAddress"]');
 
+  var entityIdUrl = Fliplet.Env.get('apiUrl') + 'v1/session/providers/saml2/metadata';
+
+  if (data.dynamicEntityId) {
+    entityIdUrl += '/' + appId;
+  } else {
+    entityIdUrl += '?appId=' + appId;
+  }
+
   $('#entity_id').attr('data-clipboard-text', appId
-    ? Fliplet.Env.get('apiUrl') + 'v1/session/providers/saml2/metadata?appId=' + appId
+    ? entityIdUrl
     : 'App ID invalid'
   );
 
@@ -35,7 +47,8 @@ Fliplet().then(function() {
       dataSourceId: $dataSources.val(),
       dataSourceEmailColumn: $emailAddress.val() !== 'none'
         ? $emailAddress.val()
-        : undefined
+        : undefined,
+      dynamicEntityId: data.dynamicEntityId,
     }).then(function() {
       Fliplet.Widget.complete();
     });

--- a/js/interface.js
+++ b/js/interface.js
@@ -3,7 +3,7 @@ Fliplet().then(function() {
   var appId = Fliplet.Env.get('appId');
 
   if (!$('[name="sso_login_url"]').val()) {
-    data.dynamicEntityId = data.dynamicEntityId || true;
+    data.dynamicEntityId = true;
   }
 
   $(window).on('resize', Fliplet.Widget.autosize);

--- a/js/interface.js
+++ b/js/interface.js
@@ -11,16 +11,16 @@ Fliplet().then(function() {
   var $dataSources = $('[name="dataSource"]');
   var $emailAddress = $('[name="emailAddress"]');
 
-  var entityIdUrl = Fliplet.Env.get('apiUrl') + 'v1/session/providers/saml2/metadata';
+  var metadataUrl = Fliplet.Env.get('apiUrl') + 'v1/session/providers/saml2/metadata';
 
   if (data.dynamicEntityId) {
-    entityIdUrl += '/' + appId;
+    metadataUrl += '/' + appId;
   } else {
-    entityIdUrl += '?appId=' + appId;
+    metadataUrl += '?appId=' + appId;
   }
 
   $('#entity_id').attr('data-clipboard-text', appId
-    ? entityIdUrl
+    ? metadataUrl
     : 'App ID invalid'
   );
 


### PR DESCRIPTION
New instances of this component will have a slightly different URL for the XML file which has a different URL for the entity ID and callback URL.

This allows clients to set up Fliplet as a provider in their system multiple times (given it's for different apps).

---

backend ref https://github.com/Fliplet/fliplet-api/pull/4156