### PR TITLE
ID-1630 [Fix] Defaults force auth to checked

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -31,9 +31,8 @@ Fliplet().then(function() {
     $('[name="validateSession"]').prop('checked', true);
   }
 
-  if (data.sp && data.sp.force_authn) {
-    $('[name="forceAuthentication"]').prop('checked', true);
-  }
+  // Defaults to checked
+  $('[name="forceAuthentication"]').prop('checked', data.sp && data.sp.force_authn === false ? false : true);
 
   var clipboard = new Clipboard('#entity_id');
   clipboard.on('success', function(e) {


### PR DESCRIPTION
The backend defaults to `true` when the option is not set by the UI. The UI should clearly mark the checkbox as selected when no value was found in the settings.