### PR TITLE
XOR-601 [FEAT] Ensure saml2 sessions has positive length passports array

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -26,7 +26,7 @@ Fliplet.Widget.register('com.fliplet.sso.saml2', function registerComponent() {
             url: (Fliplet.Env.get('primaryApiUrl') || Fliplet.Env.get('apiUrl')) + 'v1/session/authorize/saml2?appId=' + Fliplet.Env.get('masterAppId') + '&auth_token=' + Fliplet.User.getAuthToken(),
             onclose: function() {
               Fliplet.Session.get().then(function(session) {
-                if (session.server.passports.saml2) {
+                if (session.server.passports.saml2 && session.server.passports.saml2.length) {
                   return resolve();
                 }
 


### PR DESCRIPTION
### Product areas affected

Session-> Passport -> saml2

### What does this PR do?

This PR has been updated to check that `session.server.passports.saml2` is an array with positive length. 

### JIRA ticket

[XOR-4](https://weboo.atlassian.net/browse/XOR-4)
[XOR-601
](https://weboo.atlassian.net/browse/XOR-601)