### PR TITLE
PS-571 [Fix] Ensure session minute values are stored in DS definition

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -125,7 +125,13 @@ Fliplet().then(function() {
           onDataSourceSelect(dataSource);
         }
 
-        currentDataSource = dataSource.id ? dataSource : null;
+        // Only assign selected DS when current DS in not available or not as same as selected DS
+        if (!currentDataSource
+          || (dataSource && dataSource.id && dataSource.id !== currentDataSource.id)
+          || (dataSource.data && dataSource.data.id && dataSource.data.id !== currentDataSource.id)) {
+          currentDataSource = dataSource.id ? dataSource : null;
+          currentDataSource = currentDataSource || dataSource.data;
+        }
       }
     });
 


### PR DESCRIPTION
This PR ensures that selected DS is assigned only when current DS in not available or not as same as selected DS
[PS-571](https://weboo.atlassian.net/browse/PS-571)

[PS-571]: https://weboo.atlassian.net/browse/PS-571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ