### PR TITLE
PS-1802 [Fix] Azure AD SSO login broken by COOP headers

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -18,25 +18,83 @@ Fliplet.Widget.register('com.fliplet.sso.saml2', function registerComponent() {
       // as the resulting session which could have been generated if this went out with an app token instead.
       return Fliplet.Session.get().then(function() {
         return new Promise(function(resolve, reject) {
+          var authUrl = (Fliplet.Env.get('primaryApiUrl') || Fliplet.Env.get('apiUrl')) + 'v1/session/authorize/saml2?appId=' + Fliplet.Env.get('masterAppId') + '&auth_token=' + Fliplet.User.getAuthToken();
+
+          function onSessionReady(session) {
+            return Promise.all([
+              Fliplet.App.Storage.set('fl-chat-auth-email', session.user.email),
+              Fliplet.App.Storage.set('fl-chat-user-token', session.auth_token)
+            ]).then(function() {
+              if (session.server.passports.saml2 && session.server.passports.saml2.length) {
+                return resolve();
+              }
+            })
+              .catch(function() {
+                reject(T('widgets.saml2.errors.loginNotComplete'));
+              });
+          }
+
+          // On web, use session polling to detect auth completion.
+          // This avoids relying on popup.closed which is blocked by
+          // Cross-Origin-Opener-Policy headers set by IdPs like Azure AD.
+          if (Fliplet.Env.get('platform') === 'web') {
+            var popup = window.open(authUrl, '_blank');
+            var sessionPollTimer = setInterval(function() {
+              var popupClosed = false;
+
+              try {
+                popupClosed = !popup || popup.closed;
+              } catch (e) {
+                // COOP may block access to popup.closed
+              }
+
+              Fliplet.Session.get().then(function(session) {
+                if (session && session.server && session.server.passports
+                    && session.server.passports.saml2
+                    && session.server.passports.saml2.length) {
+                  clearInterval(sessionPollTimer);
+
+                  // Close the popup if it's still open and accessible
+                  try {
+                    if (popup && !popup.closed) {
+                      popup.close();
+                    }
+                  } catch (e) {
+                    // Ignore if COOP blocks access
+                  }
+
+                  onSessionReady(session);
+                } else if (popupClosed) {
+                  // Popup was closed without completing auth — check session one last time
+                  clearInterval(sessionPollTimer);
+                  Fliplet.Session.get().then(function(finalSession) {
+                    if (finalSession && finalSession.server && finalSession.server.passports
+                        && finalSession.server.passports.saml2
+                        && finalSession.server.passports.saml2.length) {
+                      onSessionReady(finalSession);
+                    } else {
+                      reject(T('widgets.saml2.errors.loginNotComplete'));
+                    }
+                  }).catch(function() {
+                    reject(T('widgets.saml2.errors.loginNotComplete'));
+                  });
+                }
+              });
+            }, 1000);
+
+            return;
+          }
+
+          // Native platforms: use InAppBrowser via Fliplet.Navigate.to with onclose
           Fliplet.Navigate.to({
             action: 'url',
             inAppBrowser: inAppBrowser,
             basicAuth: opts.basicAuth,
             handleAuthorization: false,
-            url: (Fliplet.Env.get('primaryApiUrl') || Fliplet.Env.get('apiUrl')) + 'v1/session/authorize/saml2?appId=' + Fliplet.Env.get('masterAppId') + '&auth_token=' + Fliplet.User.getAuthToken(),
+            url: authUrl,
             onclose: function() {
               Fliplet.Session.get().then(function(session) {
-                return Promise.all([
-                  Fliplet.App.Storage.set('fl-chat-auth-email', session.user.email),
-                  Fliplet.App.Storage.set('fl-chat-user-token', session.auth_token)
-                ]).then(function() {
-                  if (session.server.passports.saml2 && session.server.passports.saml2.length) {
-                    return resolve();
-                  }
-                })
-                  .catch(function() {
-                    reject(T('widgets.saml2.errors.loginNotComplete'));
-                  });
+                onSessionReady(session);
               });
             }
           });


### PR DESCRIPTION
## Summary
- Azure AD enforces `Cross-Origin-Opener-Policy: same-origin` on `login.microsoftonline.com`, which blocks `popup.closed` access and causes the SSO popup close detection to fail silently
- On web, the login screen gets stuck on "Please Wait..." forever because the `onclose` callback never fires
- Fix: on web platform, open the popup directly and poll `Fliplet.Session.get()` every 1s to detect when SAML2 auth completes, bypassing the broken `popup.closed` mechanism
- Native platforms (iOS/Android) continue using InAppBrowser with `onclose` — unaffected by COOP since IAB uses native events, not `window.opener`

## Test plan
- [ ] Azure AD SSO login on web — should no longer get stuck on "Please Wait..."
- [ ] Non-Azure SSO providers (Okta, Google) on web — should still work
- [ ] SSO on iOS/Android native app — verify no regression (InAppBrowser path unchanged)
- [ ] User closes popup before completing auth — should show login error
- [ ] Verify no console spam from COOP errors during polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)