### PR TITLE
Fix Profile Data Source not remapped on app clone

### DIFF
--- a/widget.json
+++ b/widget.json
@@ -5,7 +5,7 @@
   "icon": "img/icon.png",
   "tags": ["type:appComponent", "visibility:hidden"],
   "provider_only": false,
-  "references": [],
+  "references": ["dataSourceId:dataSource"],
   "html_tag": "div",
   "settings": {
     "excludedProperties": ["idp.certificates"],


### PR DESCRIPTION
## Summary
- Add missing `dataSourceId:dataSource` reference to `widget.json`
- Without this, the app clone process cannot discover the SSO Profile Data Source to clone it, and cannot remap the ID in the cloned widget config
- Cloned apps kept the original app's Profile DS ID, causing SSO login to fail silently (SAML passport stored in wrong session)

**Jira:** [PS-1802](https://weboo.atlassian.net/browse/PS-1802)

## Root cause
The `dataSourceId` setting was added in June 2020 but `widget.json` references were never updated from `[]`. The clone process uses `widget.references` for both:
1. **Discovery** (`page.getWidgetInstancesByReference('dataSource')`) — which DSs to clone
2. **Remapping** (`widgetInstance.updateReferences()`) — replacing old DS IDs with new ones

Both fail silently when the reference is missing.

## Test plan
- [ ] Clone an app that has SSO SAML2 configured with a Profile Data Source
- [ ] Verify the cloned app's SSO widget settings point to the NEW (cloned) data source, not the original
- [ ] Verify SSO login works on the cloned app's published web app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PS-1802]: https://weboo.atlassian.net/browse/PS-1802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ