### PR TITLE
Release/dev 935

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -17,13 +17,28 @@ Fliplet.Widget.register('com.fliplet.sso.saml2', function registerComponent() {
       // Ensure a session is created so that the token being used by the system browser (or IAB) is the same
       // as the resulting session which could have been generated if this went out with an app token instead.
       return Fliplet.Session.get().then(function() {
+        // Exchange the real session token for a one-time state token so that
+        // auth_token never appears in the URL opened in the in-app browser.
+        return Fliplet.API.request({
+          url: 'v1/session/authorize/state',
+          method: 'POST',
+          data: { appId: Fliplet.Env.get('masterAppId'), sso: true }
+        }).catch(function(err) {
+          console.error('[Fliplet.SSO.SAML2] Failed to obtain state token', err);
+          return { state: null };
+        });
+      }).then(function(response) {
+        var authParam = response.state
+          ? '&state=' + response.state
+          : '&auth_token=' + Fliplet.User.getAuthToken();
+
         return new Promise(function(resolve, reject) {
           Fliplet.Navigate.to({
             action: 'url',
             inAppBrowser: inAppBrowser,
             basicAuth: opts.basicAuth,
             handleAuthorization: false,
-            url: (Fliplet.Env.get('primaryApiUrl') || Fliplet.Env.get('apiUrl')) + 'v1/session/authorize/saml2?appId=' + Fliplet.Env.get('masterAppId') + '&auth_token=' + Fliplet.User.getAuthToken(),
+            url: (Fliplet.Env.get('primaryApiUrl') || Fliplet.Env.get('apiUrl')) + 'v1/session/authorize/saml2?appId=' + Fliplet.Env.get('masterAppId') + authParam,
             onclose: function() {
               Fliplet.Session.get().then(function(session) {
                 return Promise.all([


### PR DESCRIPTION
Exchange the real session token for a short-lived, one-time state token
(Redis-backed, 60s TTL) before opening the SAML2 authorize URL in the
in-app browser. The auth_token no longer appears in the IAB URL, removing
exposure via browser history, proxy logs, and Referrer headers.