### PR TITLE
fix(PS-1893): route SSO SAML2 auth through app's regional API

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -38,7 +38,7 @@ Fliplet.Widget.register('com.fliplet.sso.saml2', function registerComponent() {
           : '&auth_token=' + Fliplet.User.getAuthToken();
 
         return new Promise(function(resolve, reject) {
-          var authUrl = (Fliplet.Env.get('primaryApiUrl') || Fliplet.Env.get('apiUrl')) + 'v1/session/authorize/saml2?appId=' + appId + '&auth_token=' + Fliplet.User.getAuthToken();
+          var authUrl = Fliplet.Env.get('apiUrl') + 'v1/session/authorize/saml2?appId=' + appId + '&auth_token=' + Fliplet.User.getAuthToken();
 
           console.log(logPrefix, 'navigating to auth URL:', authUrl.replace(/auth_token=[^&]+/, 'auth_token=REDACTED'));
 
@@ -47,7 +47,7 @@ Fliplet.Widget.register('com.fliplet.sso.saml2', function registerComponent() {
             inAppBrowser: inAppBrowser,
             basicAuth: opts.basicAuth,
             handleAuthorization: false,
-            url: (Fliplet.Env.get('primaryApiUrl') || Fliplet.Env.get('apiUrl')) + 'v1/session/authorize/saml2?appId=' + Fliplet.Env.get('masterAppId') + authParam,
+            url: Fliplet.Env.get('apiUrl') + 'v1/session/authorize/saml2?appId=' + Fliplet.Env.get('masterAppId') + authParam,
             onclose: function() {
               console.log(logPrefix, 'onclose fired, fetching session...');
 


### PR DESCRIPTION
## Summary

- Replace `primaryApiUrl` with `apiUrl` when redirecting the in-app browser to `/v1/session/authorize/saml2`, so the entire SSO flow runs on the app's own regional API (and its Redis ElastiCache).
- Fixes \"You didn't finish the login process\" for SAML2 logins in US and CA apps.

## Root cause

The state token minted by `POST /v1/session/authorize/state` (see `routes/v1/session.js`) is written to `database.redis`, which `libs/database.js` binds to the **local ECS region's** ElastiCache only. Each region has its own cluster:

| Region | ElastiCache endpoint |
|---|---|
| eu-west-1 | `fliplet-redis-production.z7qaav.0001.euw1.cache.amazonaws.com` |
| us-west-1 | `fliplet-redis-production.hjk3zi.0001.usw1.cache.amazonaws.com` |
| ca-central-1 | `fliplet-redis-production.zf4cbh.0001.cac1.cache.amazonaws.com` |

The widget's `Fliplet.API.request` posts to `apiUrl` (the app's region) — so for a US app, the state UUID is stored in **US Redis**. The widget then redirected the in-app browser to `(primaryApiUrl || apiUrl)` for `/authorize/saml2` — and `primaryApiUrl` resolves to the EU primary `api.fliplet.com` for any non-custom-domain app (see `libs/engine/index.js:257`). EU `database.redis.evalAsync('sso:state:<uuid>')` missed, the state was silently dropped, the SAML2 session was created on EU, and the passport was stored against an EU session that the browser's app session (in US) never sees.

Confirmed against Datadog logs for app 366171: SAML2 LOGIN + CALLBACK both ran on EU ECS using session `8418807`, while the widget's app session was `8403270` (US).

## Fix

`js/build.js`: use `Fliplet.Env.get('apiUrl')` directly for the SAML2 authorize URL.

For non-custom-domain apps, `apiUrl` is the regional API (`us-api.fliplet.com` / `ca-api.fliplet.com` / `api.fliplet.com`). For custom-domain apps, `apiUrl === primaryApiUrl === https://<custom-domain>/` per `libs/engine/index.js:232-236`, so this is a no-op for them.

After the fix, every step of the SSO flow runs on the same region:

| Step | Hits |
|---|---|
| `POST /authorize/state` (mint) | Regional API → regional Redis |
| Redirect to `/authorize/saml2` | Regional API → regional Redis (state resolves ✓) |
| SP `entity_id` / `assert_endpoint` | Regional host (matches metadata in `interface.js`) |
| IdP callback POST | Regional API → regional session |
| `Fliplet.Session.get()` after IAB closes | Regional API → same session ✓ |

## Test plan

- [ ] Verify a US app's SAML2 login completes end-to-end (no \"You didn't finish the login process\") and `session.server.passports.saml2` is present after the in-app browser closes.
- [ ] Verify the same for a CA app.
- [ ] Regression: verify EU non-custom-domain apps still log in successfully.
- [ ] Regression: verify a custom-domain app (any region) still logs in successfully and SP `entity_id` / `assert_endpoint` remain on the custom domain.
- [ ] Confirm Datadog SAML2 callback logs now show `hostRegion` matching the app's `dbRegion`, and the session ID matches the browser's app session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)