### PR TITLE
Route SSO SAML2 auth through the app's regional API (#50)

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -38,7 +38,7 @@ Fliplet.Widget.register('com.fliplet.sso.saml2', function registerComponent() {
           : '&auth_token=' + Fliplet.User.getAuthToken();
 
         return new Promise(function(resolve, reject) {
-          var authUrl = (Fliplet.Env.get('primaryApiUrl') || Fliplet.Env.get('apiUrl')) + 'v1/session/authorize/saml2?appId=' + appId + '&auth_token=' + Fliplet.User.getAuthToken();
+          var authUrl = Fliplet.Env.get('apiUrl') + 'v1/session/authorize/saml2?appId=' + appId + '&auth_token=' + Fliplet.User.getAuthToken();
 
           console.log(logPrefix, 'navigating to auth URL:', authUrl.replace(/auth_token=[^&]+/, 'auth_token=REDACTED'));
 
@@ -47,7 +47,7 @@ Fliplet.Widget.register('com.fliplet.sso.saml2', function registerComponent() {
             inAppBrowser: inAppBrowser,
             basicAuth: opts.basicAuth,
             handleAuthorization: false,
-            url: (Fliplet.Env.get('primaryApiUrl') || Fliplet.Env.get('apiUrl')) + 'v1/session/authorize/saml2?appId=' + Fliplet.Env.get('masterAppId') + authParam,
+            url: Fliplet.Env.get('apiUrl') + 'v1/session/authorize/saml2?appId=' + Fliplet.Env.get('masterAppId') + authParam,
             onclose: function() {
               console.log(logPrefix, 'onclose fired, fetching session...');
 


### PR DESCRIPTION
The widget redirected the in-app browser to primaryApiUrl (the EU primary api.fliplet.com) for /v1/session/authorize/saml2. The state token created via /v1/session/authorize/state is stored in the app's regional Redis (per-region ElastiCache, no replication), so the EU lookup missed and the SAML2 session/passport ended up on a different session than the widget reads back via apiUrl, surfacing as "You didn't finish the login process" for US/CA apps.

Use apiUrl for the authorize redirect so the entire SSO flow — state mint, state lookup, SP entity_id/assert_endpoint, IdP callback, session, and post-flow Fliplet.Session.get() — runs on the same regional API and Redis. No-op for EU and custom-domain apps where apiUrl already equals primaryApiUrl.