### PR TITLE
fix(DEV-1114): use system Safari for SSO on all iOS versions

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -8,12 +8,29 @@ Fliplet.Widget.register('com.fliplet.sso.saml2', function registerComponent() {
 
       var inAppBrowser = true;
 
-      // Use Safari on iOS12 to prevent issues with cookies not being saved.
+      // DEV-1114 / PS-1748: Use system Safari for SSO on all iOS versions to
+      // bypass the Cordova in-app browser cookie isolation. CDVWKInAppBrowser
+      // creates a new WKProcessPool on every open (CDVWKInAppBrowser.m:149)
+      // which flushes cookies between launches, so SSO sessions never persist
+      // and users are prompted to re-authenticate every app launch (Paul Weiss
+      // symptom). System Safari has its own persistent cookie store, so SSO
+      // sessions survive app launches.
+      //
+      // Originally (commit 4682f4e, Mar 2020) this workaround was scoped to
+      // iOS 12 to address an Apple SameSite cookie bug specific to that
+      // version. Apple fixed the SameSite bug in iOS 13, but the IAB cookie
+      // flush is a separate issue that affects all iOS versions — generalising
+      // the workaround to all iOS covers both.
+      //
       // ref: https://www.chromium.org/updates/same-site/incompatible-clients
-      if (Modernizr.ios && Fliplet.Navigator.device().version.toString().indexOf('12') === 0) {
+      // The proper architectural fix (ASWebAuthenticationSession) is tracked
+      // separately under DEV-1115.
+      if (Modernizr.ios) {
         inAppBrowser = false;
 
-        // Allow pause/resume events to be registered
+        // Allow pause/resume events to be registered (the existing iOS 12
+        // path used this to detect SSO completion when the in-app browser
+        // is bypassed — same mechanism applies on iOS 13+).
         opts.basicAuth = true;
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-sso-saml2",
-  "version": "1.0.0",
+  "version": "1.0.7",
   "description": "Documentation is available at https://developers.fliplet.com/API/integrations/sso-saml2.html",
   "main": "index.js",
   "scripts": {

--- a/widget.json
+++ b/widget.json
@@ -1,7 +1,7 @@
 {
   "name": "SAML2 SSO",
   "package": "com.fliplet.sso.saml2",
-  "version": "1.0.0",
+  "version": "1.0.7",
   "icon": "img/icon.png",
   "tags": ["type:appComponent", "visibility:hidden"],
   "provider_only": false,


### PR DESCRIPTION
## Why

Customer trigger: PS-1748 (Paul Weiss) — iOS users prompted to re-authenticate via SSO on every app launch. Open since 20 Feb. Their tech team proposed Intune App SDK as the fix; the actual root cause is in the Cordova in-app browser plugin.

## Companion PR

OAuth2 widget gets the same fix in [fliplet-widget-sso-oauth2 PR #1](https://github.com/Fliplet/fliplet-widget-sso-oauth2/pull/1). Both should ship together so all SSO clients (SAML2 + OAuth2) get the iOS cookie persistence fix.

## Root cause

`CDVWKInAppBrowser.m:149` (in `fliplet-ios-version-2`) explicitly creates a new `WKProcessPool` on every open:

```objc
self.inAppBrowserViewController.webView.configuration.processPool = [[WKProcessPool alloc] init]; // create new process pool to flush all data
```

This wipes cookies between every IAB open, so SSO sessions never survive an app launch. This is a Cordova plugin behaviour, **not** an Intune limitation — Intune just compounds the visibility because the IAB is sandboxed even more strictly under MDM.

## The fix (1 line of executable code)

Generalises the iOS 12-only system-Safari escape hatch that Nicholas Valbusa added in March 2020 (commit 4682f4e). Original intent was to work around an Apple SameSite cookie bug specific to iOS 12 (fixed in iOS 13). The escape hatch happens to also bypass the IAB process pool flush by routing through system Safari instead.

```diff
- if (Modernizr.ios && Fliplet.Navigator.device().version.toString().indexOf('12') === 0) {
+ if (Modernizr.ios) {
    inAppBrowser = false;
    opts.basicAuth = true;
  }
```

The rest of the diff is comments documenting the rationale.

## Version bump

`widget.json` and `package.json`: 1.0.0 → 1.0.7 (matches expected next published tag).

## Why this works

`Fliplet.Navigate.to({ inAppBrowser: false, basicAuth: true })` opens the URL in **system Safari**, which:
- Has its own persistent cookie store (survives app launches)
- Is trusted by Intune (it's the system browser)
- Already worked for iOS 12 with this exact code path

`opts.basicAuth = true` registers Cordova pause/resume events to detect when the user returns to the app from system Safari (so the `onclose` callback still fires and the widget can fetch the new session).

## Deploy mechanism

**Widget update via CDN — no native app rebuild required, no App Store / Play Store / Intune redeploy required.**

After merge:
1. Widget version bumps and publishes to CDN
2. Apps republish from Studio → pick up new widget
3. PW users get the fix on next app launch after republish

PW timeline: hours from this PR landing to their users having the fix.

## Verification needed before promising fix to PW

1. **Real iOS 13+ device test** on a Fliplet test app with SAML2 SSO
   - Confirm SSO completes and session persists
   - Confirm `onclose` fires correctly via pause/resume on iOS 13+ (the iOS 12 path uses this; needs verification that newer iOS still does)
2. **Test return-to-app behaviour** — does the user end up back in the app cleanly after IdP auth?
3. **Test on Intune-wrapped app** if possible (PW environment)

If pause/resume doesn't fire reliably on iOS 13+, we may need a fallback callback mechanism or timeout. The existing iOS 12 path was tested and works, so the mechanism is sound — just need to confirm it generalises.

## Does NOT fix

- **Android users.** The widget escape hatch only routes through system Safari on iOS. Android needs the proper Chrome Custom Tabs implementation, tracked separately under [DEV-1115](https://weboo.atlassian.net/browse/DEV-1115). Per Carina, PW is "mostly iOS, few Android" — so this PR helps the majority of their affected users.
- **Non-SSO in-app browser usage.** This change only affects the SSO flow's browser choice. Other `Fliplet.Navigate.to({inAppBrowser: true})` calls are untouched.
- **The fundamental architecture.** In-app browser cookie isolation is a real bug class. This PR routes around it for SSO; the proper fix is ASWebAuthenticationSession (iOS) and Chrome Custom Tabs (Android), tracked under DEV-1115.

## OAuth2 widget — companion PR shipped

[fliplet-widget-sso-oauth2 PR #1](https://github.com/Fliplet/fliplet-widget-sso-oauth2/pull/1) applies the same pattern. Both should ship together.

## Canary option

If we want to ship cautiously, gate by app ID:

```js
var canaryAppIds = ['12300']; // PW Directory
var enableSystemBrowser = canaryAppIds.indexOf(Fliplet.Env.get('masterAppId')) !== -1;
if (Modernizr.ios && enableSystemBrowser) { ... }
```

I've left this out of this PR for simplicity — happy to add if reviewers prefer canary rollout. Widgets roll back easily by republishing the previous version.

## References

- [DEV-1114](https://weboo.atlassian.net/browse/DEV-1114) (this ticket)
- [DEV-1115](https://weboo.atlassian.net/browse/DEV-1115) (long-term mobile SSO modernisation)
- [PS-1748](https://weboo.atlassian.net/browse/PS-1748) (Paul Weiss customer ticket — re-opened)
- Original iOS 12 commit: 4682f4e by Nicholas Valbusa, 24 Mar 2020
- CDVWKInAppBrowser.m:149 — the WKProcessPool flush behaviour
- Companion PR: [fliplet-widget-sso-oauth2 PR #1](https://github.com/Fliplet/fliplet-widget-sso-oauth2/pull/1)

## Reviewers

@Arpanexe — primary (mobile pipeline owner)
@farhantariq12b — second

[DEV-1115]: https://weboo.atlassian.net/browse/DEV-1115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ