### PR TITLE
Release: projects/PS-1784-Paul-weiss → master

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -8,12 +8,29 @@ Fliplet.Widget.register('com.fliplet.sso.saml2', function registerComponent() {
 
       var inAppBrowser = true;
 
-      // Use Safari on iOS12 to prevent issues with cookies not being saved.
+      // DEV-1114 / PS-1748: Use system Safari for SSO on all iOS versions to
+      // bypass the Cordova in-app browser cookie isolation. CDVWKInAppBrowser
+      // creates a new WKProcessPool on every open (CDVWKInAppBrowser.m:149)
+      // which flushes cookies between launches, so SSO sessions never persist
+      // and users are prompted to re-authenticate every app launch (Paul Weiss
+      // symptom). System Safari has its own persistent cookie store, so SSO
+      // sessions survive app launches.
+      //
+      // Originally (commit 4682f4e, Mar 2020) this workaround was scoped to
+      // iOS 12 to address an Apple SameSite cookie bug specific to that
+      // version. Apple fixed the SameSite bug in iOS 13, but the IAB cookie
+      // flush is a separate issue that affects all iOS versions — generalising
+      // the workaround to all iOS covers both.
+      //
       // ref: https://www.chromium.org/updates/same-site/incompatible-clients
-      if (Modernizr.ios && Fliplet.Navigator.device().version.toString().indexOf('12') === 0) {
+      // The proper architectural fix (ASWebAuthenticationSession) is tracked
+      // separately under DEV-1115.
+      if (Modernizr.ios) {
         inAppBrowser = false;
 
-        // Allow pause/resume events to be registered
+        // Allow pause/resume events to be registered (the existing iOS 12
+        // path used this to detect SSO completion when the in-app browser
+        // is bypassed — same mechanism applies on iOS 13+).
         opts.basicAuth = true;
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-sso-saml2",
-  "version": "1.0.0",
+  "version": "1.0.7",
   "description": "Documentation is available at https://developers.fliplet.com/API/integrations/sso-saml2.html",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-sso-saml2",
-  "version": "1.0.7",
+  "version": "1.0.0",
   "description": "Documentation is available at https://developers.fliplet.com/API/integrations/sso-saml2.html",
   "main": "index.js",
   "scripts": {

--- a/widget.json
+++ b/widget.json
@@ -1,7 +1,7 @@
 {
   "name": "SAML2 SSO",
   "package": "com.fliplet.sso.saml2",
-  "version": "1.0.0",
+  "version": "1.0.7",
   "icon": "img/icon.png",
   "tags": ["type:appComponent", "visibility:hidden"],
   "provider_only": false,

--- a/widget.json
+++ b/widget.json
@@ -1,7 +1,7 @@
 {
   "name": "SAML2 SSO",
   "package": "com.fliplet.sso.saml2",
-  "version": "1.0.7",
+  "version": "1.0.0",
   "icon": "img/icon.png",
   "tags": ["type:appComponent", "visibility:hidden"],
   "provider_only": false,
@@ -12,25 +12,11 @@
     "protected": ["idp.certificates"]
   },
   "interface": {
-    "dependencies": [
-      "fliplet-core",
-      "fliplet-studio-ui",
-      "fliplet-datasources",
-      "bootstrap"
-    ],
-    "assets": [
-      "js/interface.js",
-      "vendor/clipboard.min.js",
-      "css/interface.css"
-    ]
+    "dependencies": ["fliplet-core", "fliplet-studio-ui", "fliplet-datasources", "bootstrap"],
+    "assets": ["js/interface.js", "vendor/clipboard.min.js", "css/interface.css"]
   },
   "build": {
-    "dependencies": [
-      "fliplet-core",
-      "fliplet-session"
-    ],
-    "assets": [
-      "js/build.js"
-    ]
+    "dependencies": ["fliplet-core", "fliplet-session"],
+    "assets": ["js/build.js"]
   }
 }


### PR DESCRIPTION
## Release: `projects/PS-1784-Paul-weiss` → `master`

| Title | Ticket | PR |
|-------|--------|-----|
| Use system Safari for SSO on all iOS versions | [DEV-1114](https://weboo.atlassian.net/browse/DEV-1114) | #52 |

### Deployment instructions
- Widget update via CDN — no native app rebuild required.
- Widget version is currently `1.0.0` on this branch (reset via commit 12770cd). Bump to the next published tag before publishing to the CDN so existing apps pick up the fix on republish.
- After publish, apps republish from Studio to pick up the new widget; iOS users get the fix on next app launch.
- Companion: ship together with `fliplet-widget-sso-oauth2` PR #1 so both SAML2 + OAuth2 SSO clients are fixed.

[DEV-1114]: https://weboo.atlassian.net/browse/DEV-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ