### PR TITLE
DEV-1208 Hide advanced SSO settings under "Change Recommended Settings"

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -35,3 +35,32 @@
 body {
   overflow-y: hidden;
 }
+
+.advanced-settings-toggle {
+  margin: 15px 0;
+}
+
+.advanced-settings-toggle a {
+  color: #00abd1;
+  cursor: pointer;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.advanced-settings-toggle a:hover,
+.advanced-settings-toggle a:focus {
+  text-decoration: underline;
+}
+
+.advanced-settings-toggle .toggle-chevron {
+  transition: transform 0.2s ease-in-out;
+  margin-right: 4px;
+}
+
+.advanced-settings-toggle a.expanded .toggle-chevron {
+  transform: rotate(90deg);
+}
+
+.advanced-settings-panel {
+  margin-top: 10px;
+}

--- a/interface.html
+++ b/interface.html
@@ -49,64 +49,71 @@
   </div>
   <!-- end of disabled section-->
 
-  <div class="form-group">
-    <div class="col-sm-4 control-label">
-      <label for="forceAuthentication">Force authentication</label>
-      <p class="help-block"><small>When enabled, your Identity Provider will require the user to authenticate even if they have previously logged in on the same device and browser.</small></p>
-    </div>
-    <div class="col-sm-8">
-      <input type="checkbox" id="forceAuthentication" name="forceAuthentication" /> User must authenticate with the Identity Provider every time they log in.
-    </div>
+  <div class="advanced-settings-toggle">
+    <a role="button" data-toggle="collapse" href="#advancedSettings" aria-expanded="false" aria-controls="advancedSettings">
+      <i class="fa fa-chevron-right toggle-chevron"></i> Change Recommended Settings
+    </a>
   </div>
 
-  <h3></h3>
-  <div class="form-group clearfix">
-    <div class="col-sm-4 control-label">
-      <label for="loggedInUserTime">Keep the user logged in for
-        <a class="help-icon" data-toggle="tooltip" data-placement="top" title="Force user re-authentication after a number of hours">
-          <i class="fa fa-question-circle-o"></i>
-        </a>
-      </label>
-    </div>
-    <div class="col-sm-8">
-      <div class="input-group">
-        <input type="number" class="form-control logged-user" name="loggedInUserTime" min="0" oninput="validity.valid||(value='');" value="{{sessionMaxDurationMinutes}}">
-        <span class="input-group-addon time-label">Hours</span>
+  <div class="collapse advanced-settings-panel" id="advancedSettings">
+    <div class="form-group">
+      <div class="col-sm-4 control-label">
+        <label for="forceAuthentication">Force authentication</label>
+        <p class="help-block"><small>When enabled, your Identity Provider will require the user to authenticate even if they have previously logged in on the same device and browser.</small></p>
+      </div>
+      <div class="col-sm-8">
+        <input type="checkbox" id="forceAuthentication" name="forceAuthentication" /> User must authenticate with the Identity Provider every time they log in.
       </div>
     </div>
-  </div>
-  <div class="form-group clearfix">
-    <div class="col-sm-4 control-label">
-      <label for="loggedOutUserTime">Automatically log out the user due to inactivity after
-        <a class="help-icon" data-toggle="tooltip" data-placement="top" title="Automatic logout of the user after a period of inactivity in the app">
-          <i class="fa fa-question-circle-o"></i>
-        </a>
-      </label>
-    </div>
-    <div class="col-sm-8">
-      <div class="input-group">
-        <input type="number" class="form-control logged-user" name="loggedOutUserTime" min="0" oninput="validity.valid||(value='');" value="{{sessionIdleTimeoutMinutes}}">
-        <span class="input-group-addon time-label">Minutes</span>
-      </div>
-    </div>
-  </div>
 
-  <h3><small>Additional profile data</small></h3>
-  <p class="text-helper">You can optionally add profile data to the SAML2 login</p>
-  <div class="form-group clearfix">
-    <div id="dataSourceProvider" class="col-sm-8"></div>
-  </div>
-  <div class="form-group hidden" id="select-email-field">
-    <div class="col-sm-4 control-label">
-      <label for="emailColumn">Select the email field</label>
+    <div class="form-group clearfix">
+      <div class="col-sm-4 control-label">
+        <label for="loggedInUserTime">Keep the user logged in for
+          <a class="help-icon" data-toggle="tooltip" data-placement="top" title="Force user re-authentication after a number of hours">
+            <i class="fa fa-question-circle-o"></i>
+          </a>
+        </label>
+      </div>
+      <div class="col-sm-8">
+        <div class="input-group">
+          <input type="number" class="form-control logged-user" name="loggedInUserTime" min="0" oninput="validity.valid||(value='');" value="{{sessionMaxDurationMinutes}}">
+          <span class="input-group-addon time-label">Hours</span>
+        </div>
+      </div>
     </div>
-    <div class="col-sm-8">
-      <label for="emailColumn" class="select-proxy-display">
-        <select name="select_email" id="emailColumn" data-label="select" class="hidden-select form-control">
-        </select>
-        <span class="icon fa fa-chevron-down"></span>
-        <span class="select-value-proxy">-- Select email field</span>
-      </label>
+    <div class="form-group clearfix">
+      <div class="col-sm-4 control-label">
+        <label for="loggedOutUserTime">Automatically log out the user due to inactivity after
+          <a class="help-icon" data-toggle="tooltip" data-placement="top" title="Automatic logout of the user after a period of inactivity in the app">
+            <i class="fa fa-question-circle-o"></i>
+          </a>
+        </label>
+      </div>
+      <div class="col-sm-8">
+        <div class="input-group">
+          <input type="number" class="form-control logged-user" name="loggedOutUserTime" min="0" oninput="validity.valid||(value='');" value="{{sessionIdleTimeoutMinutes}}">
+          <span class="input-group-addon time-label">Minutes</span>
+        </div>
+      </div>
+    </div>
+
+    <h3><small>Additional profile data</small></h3>
+    <p class="text-helper">You can optionally add profile data to the SAML2 login</p>
+    <div class="form-group clearfix">
+      <div id="dataSourceProvider" class="col-sm-8"></div>
+    </div>
+    <div class="form-group hidden" id="select-email-field">
+      <div class="col-sm-4 control-label">
+        <label for="emailColumn">Select the email field</label>
+      </div>
+      <div class="col-sm-8">
+        <label for="emailColumn" class="select-proxy-display">
+          <select name="select_email" id="emailColumn" data-label="select" class="hidden-select form-control">
+          </select>
+          <span class="icon fa fa-chevron-down"></span>
+          <span class="select-value-proxy">-- Select email field</span>
+        </label>
+      </div>
     </div>
   </div>
 </form>

--- a/js/build.js
+++ b/js/build.js
@@ -5,7 +5,6 @@ Fliplet.Widget.register('com.fliplet.sso.saml2', function registerComponent() {
   return {
     authorize: function(opts) {
       opts = opts || {};
-
       var inAppBrowser = true;
 
       // Use Safari on iOS12 to prevent issues with cookies not being saved.

--- a/js/interface.js
+++ b/js/interface.js
@@ -39,8 +39,8 @@ Fliplet().then(function() {
     data.sessionMaxDurationMinutes = $loggedInUserTime.val(data.sessionMaxDurationMinutes / minutesInHour);
   }
 
-  // Defaults to checked
-  $('[name="forceAuthentication"]').prop('checked', data.sp && data.sp.force_authn === false ? false : true);
+  // Defaults to unchecked — only enable when explicitly saved as true
+  $('[name="forceAuthentication"]').prop('checked', !!(data.sp && data.sp.force_authn === true));
 
   var clipboard = new Clipboard('#entity_id');
 
@@ -222,4 +222,29 @@ Fliplet().then(function() {
   });
 
   $('[data-toggle="tooltip"]').tooltip();
+
+  // Auto-expand advanced panel if any non-default value is already saved
+  var hasAdvancedConfig = !!(
+    (data.sp && data.sp.force_authn === true)
+    || data.sessionMaxDurationMinutes
+    || data.sessionIdleTimeoutMinutes
+    || data.dataSourceId
+  );
+
+  if (hasAdvancedConfig) {
+    $('#advancedSettings').addClass('in').attr('aria-expanded', 'true');
+    $('[href="#advancedSettings"]').attr('aria-expanded', 'true').addClass('expanded');
+  }
+
+  $('#advancedSettings').on('shown.bs.collapse hidden.bs.collapse', function() {
+    Fliplet.Widget.autosize();
+  });
+
+  $('#advancedSettings').on('show.bs.collapse', function() {
+    $('[href="#advancedSettings"]').addClass('expanded').attr('aria-expanded', 'true');
+  });
+
+  $('#advancedSettings').on('hide.bs.collapse', function() {
+    $('[href="#advancedSettings"]').removeClass('expanded').attr('aria-expanded', 'false');
+  });
 });

--- a/js/interface.js
+++ b/js/interface.js
@@ -39,10 +39,19 @@ Fliplet().then(function() {
     data.sessionMaxDurationMinutes = $loggedInUserTime.val(data.sessionMaxDurationMinutes / minutesInHour);
   }
 
-  // Defaults to checked — preserves runtime behavior for existing apps that
-  // never explicitly saved force_authn. Only flips to unchecked when an
-  // admin has explicitly saved force_authn: false.
-  $('[name="forceAuthentication"]').prop('checked', data.sp && data.sp.force_authn === false ? false : true);
+  // New instances default to unchecked per DEV-1208. For existing instances
+  // the checkbox stays checked unless force_authn was explicitly saved as
+  // false — this preserves runtime behavior because production's global
+  // saml2.force_authn default is true, so an undefined per-app value means
+  // force auth is currently ON. Flipping the default here for existing apps
+  // would silently relax auth on the next save (the saved force_authn: false
+  // would override the global default).
+  var isNewSsoInstance = !$('[name="sso_login_url"]').val();
+  $('[name="forceAuthentication"]').prop('checked',
+    isNewSsoInstance
+      ? false
+      : !(data.sp && data.sp.force_authn === false)
+  );
 
   var clipboard = new Clipboard('#entity_id');
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -39,8 +39,10 @@ Fliplet().then(function() {
     data.sessionMaxDurationMinutes = $loggedInUserTime.val(data.sessionMaxDurationMinutes / minutesInHour);
   }
 
-  // Defaults to unchecked — only enable when explicitly saved as true
-  $('[name="forceAuthentication"]').prop('checked', !!(data.sp && data.sp.force_authn === true));
+  // Defaults to checked — preserves runtime behavior for existing apps that
+  // never explicitly saved force_authn. Only flips to unchecked when an
+  // admin has explicitly saved force_authn: false.
+  $('[name="forceAuthentication"]').prop('checked', data.sp && data.sp.force_authn === false ? false : true);
 
   var clipboard = new Clipboard('#entity_id');
 
@@ -223,9 +225,10 @@ Fliplet().then(function() {
 
   $('[data-toggle="tooltip"]').tooltip();
 
-  // Auto-expand advanced panel if any non-default value is already saved
+  // Auto-expand advanced panel if any non-default value is already saved.
+  // force_authn defaults to checked, so the non-default value here is `false`.
   var hasAdvancedConfig = !!(
-    (data.sp && data.sp.force_authn === true)
+    (data.sp && data.sp.force_authn === false)
     || data.sessionMaxDurationMinutes
     || data.sessionIdleTimeoutMinutes
     || data.dataSourceId


### PR DESCRIPTION
## Summary
- Wrap **Force authentication**, **Keep user logged in**, **Auto-logout on inactivity**, and **Additional profile data** behind a single "Change Recommended Settings" collapse toggle so the default settings view shows only the IdP configuration fields.
- Auto-expand the panel when any non-default value is already saved (`force_authn: false` explicitly set, any session timing, or a profile data source), so existing custom configs stay visible.
- **Force authentication defaults to unchecked only for brand-new SSO instances** (detected by empty `sso_login_url`, matching the existing convention for `dynamicEntityId` / `validateSession`). Existing instances keep the prior "checked unless `force_authn === false` is explicitly saved" behavior.

### Why not flip the default for existing apps too?

`config/production.json` sets the global `saml2.force_authn` default to `true`, and `libs/passports/saml2.js:71` only overrides that global default when the per-app value is explicitly set:

```js
if (typeof spOptions.force_authn !== 'undefined') {
  options.force_authn = spOptions.force_authn;
}
```

So every app where `force_authn` is currently `undefined` is running with force auth ON via the global default. If the checkbox defaulted to unchecked for those apps, the next time an admin saved any SSO setting it would persist `force_authn: false` and silently relax the app's auth posture (session reuse allowed instead of forced re-auth). That's a live-behavior + security-strictness regression for an unrelated save action, which is not what DEV-1208 asks for.

`basicAuth` ownership stays on the parent SAML2 Login widget — see the sibling PR on fliplet-widget-login-saml2 for the matching Basic Auth collapse there.

## Test plan
- [ ] Open SSO settings on a fresh instance (no `sso_login_url` saved yet) → "Change Recommended Settings" collapsed; expand → Force authentication is unchecked
- [ ] Open SSO settings on an existing app with `force_authn` undefined → expand the panel; Force authentication is checked (matches current runtime behavior)
- [ ] Open settings on an app where `force_authn` is explicitly `false` (or has any session value, or a profile data source) → panel auto-expanded
- [ ] On an existing app, save without expanding the panel → confirm `force_authn: true` still gets persisted (no silent flip)
- [ ] Explicitly toggle Force authentication off inside the collapse and save → value persists as `false`; panel auto-expands on re-open
- [ ] Verify Profile data source picker still works inside the collapse
- [ ] Verify no regression to live SSO login flow on web + native

🤖 Generated with [Claude Code](https://claude.com/claude-code)